### PR TITLE
Feat/complete archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ module.exports = (eleventyConfig) => {
 
 This will expose a global data object called `mastodon` which you can use in your Eleventy project.
 
+On the first run, the plugin will fetch _all_ your public posts and then cache them to the location specified in `cacheLocation`. Each time posts are fetched after, only the posts made after the last cached post will be fetched.
+
+If you used versions < 0.2.0 you will need to clear your site's cache to get all your posts and not the most recent 40.
+
 ## Getting your Mastodon User ID
 
 I was able to retrieve my Mastodon user ID by monitoring the network requests made by the Mastodon server I belong to. On a device that is able to open developer tools, the steps I took were to:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-mastoarchive",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Expose your Mastodon posts to 11ty as a global data object",
   "main": ".eleventy.js",
   "scripts": {


### PR DESCRIPTION
Fixes #1.

If there are no cached posts, then the plugin now keeps calling the status API with the `max_id` query parameter until it receives a response with no statuses.

The `max_id` query parameter requests posts before that ID. Since the status API is limited to a response size of 40, we can keep calling the status API with this query parameter. When it returns no statuses, it has already fetched your first Mastodon post.

This will allow everyone to archive all their Mastodon posts and not start an archive with their most recent 40 posts.